### PR TITLE
Deny edits to dedicated-admins and cluster-admins groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Flask app designed to act as a webhook admission controller for OpenShift.
 
 Configuration for this webhook is provided by environment variables:
 
-* `GROUP_VALIDATION_PREFIX` - Group prefix to apply the webhook, such as `osd-` to apply to `CREATE`, `UPDATE`, `DELETE` operations on groups starting with `osd-`. (default: `osd-sre-`)
+* `GROUP_VALIDATION_PROTECTED_GROUP_REGEX` - Regular expression for protected group names, such as `osd-` to apply to `CREATE`, `UPDATE`, `DELETE` operations on groups starting with `osd-`. (default: `(^osd-sre.*|^dedicated-admins$|^cluster-admins$|^layered-cs-sre-admins$)`)
 * `GROUP_VALIDATION_ADMIN_GROUP` - Admin groups, which the requestor must be a member in order to have access granted. This is comma-separated. (default: `osd-sre-admins,osd-sre-cluster-admins`)
 * `DEBUG_GROUP_VALIDATION` - Debug the webhook? Set to `True` to enable, all other values (including absent) disable. (default: False)
 

--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -382,8 +382,8 @@ objects:
                 value: openshift-marketplace
               - name: GROUP_VALIDATION_ADMIN_GROUP
                 value: osd-sre-admins,osd-sre-cluster-admins
-              - name: GROUP_VALIDATION_PREFIX
-                value: osd-sre-
+              - name: GROUP_VALIDATION_PROTECTED_GROUP_REGEX
+                value: (^osd-sre.*|^dedicated-admins$|^cluster-admins$|^layered-cs-sre-admins$)
               command:
               - gunicorn
               - --config

--- a/src/webhook/group_validation.py
+++ b/src/webhook/group_validation.py
@@ -1,6 +1,7 @@
 from flask import request, Blueprint
 import sys, traceback
 import os
+import re
 from prometheus_client import Counter
 from webhook.request_helper import validate, responses
 
@@ -10,10 +11,12 @@ bp = Blueprint("group-webhook", __name__)
 TOTAL_GROUP = Counter('webhook_group_validation_total', 'The total number of group validation requests')
 DENIED_GROUP = Counter('webhook_group_validation_denied', 'The total number of group validation requests denied')
 
-group_prefix = os.getenv("GROUP_VALIDATION_PREFIX", "osd-sre-")
 admin_group = os.getenv("GROUP_VALIDATION_ADMIN_GROUP", "osd-sre-admins,osd-sre-cluster-admins")
 
 admin_groups = admin_group.split(",")
+
+# groups that cannot be edited by non-admins
+protected_group_regex = os.getenv("GROUP_VALIDATION_PROTECTED_GROUP_REGEX", "(^osd-sre.*|^dedicated-admins$|^cluster-admins$|^layered-cs-sre-admins$)")
 
 
 @bp.route('/group-validation', methods=['POST'])
@@ -40,35 +43,51 @@ def handle_request():
   return get_response(request, debug)
 
 
-def get_response(request, debug=False):
+def get_response(req, debug=False):
   try:
-    body_dict = request.json['request']
+    body_dict = req.json['request']
     # If trying to delete a group, must get group name from oldObject instead of object
     if body_dict['object'] is None:
       group_name = body_dict['oldObject']['metadata']['name']
     else:
       group_name = body_dict['object']['metadata']['name']
-    userinfo = body_dict['userInfo']
-    if userinfo['username'] in ("kube:admin", "system:admin"):
+    
+    userinfo = {}
+    if 'userInfo' in body_dict:
+      userinfo = body_dict['userInfo']
+    user_groups = []
+    if 'groups' in userinfo:
+      user_groups = userinfo['groups']
+
+    user_name = None
+    if 'username' in userinfo:
+      user_name = userinfo['username']
+
+    if user_name in ("kube:admin", "system:admin"):
       # kube/system admin can do anything
       if debug:
         print("Performing action: {} in {} group for {}".format(body_dict['operation'], group_name, userinfo['username']))
       return responses.response_allow(req=body_dict)
-    if group_name.startswith(group_prefix):
+
+    if re.match(protected_group_regex, group_name) is not None:
+      # attempted operation on a protected group
       if debug:
         print("Performing action: {} in {} group".format(body_dict['operation'], group_name))
-      if len(set(userinfo['groups']) & set(admin_groups)) > 0:
+      if len(set(user_groups) & set(admin_groups)) > 0:
+        # user is a member of admin groups, this is allowed
         response_body = responses.response_allow(req=body_dict, msg="{} group {}".format(body_dict['operation'], group_name))
       else:
+        # user is NOT a member of admin groups, this is denied
         deny_msg = "User not authorized to {} group {}".format(body_dict['operation'], group_name)
         response_body = responses.response_deny(req=body_dict, msg=deny_msg)
     else:
+      # was not a protected group, RBAC will handle this
       response_body = responses.response_allow(req=body_dict)
     if debug:
       print("Response body => {}".format(response_body))
     return response_body
   except Exception:
-    print("Exception when trying to access attributes. Request body: {}".format(request.json))
+    print("Exception when trying to access attributes. Request body: {}".format(req.json))
     print("Backtrace:")
     print("-" * 60)
     traceback.print_exc(file=sys.stdout)

--- a/src/webhook/namespace_validation.py
+++ b/src/webhook/namespace_validation.py
@@ -40,7 +40,12 @@ def handle_request():
 def get_response(req, debug=False):
   try:
     body_dict = req.json['request']
-    requester_group_memberships = body_dict['userInfo']['groups']
+    requester_group_memberships = []
+    if 'userInfo' in body_dict:
+      if 'groups' in body_dict['userInfo']:
+        requester_group_memberships = body_dict['userInfo']['groups']
+    else:
+      return responses.response_invalid()
     if "dedicated-admins" in requester_group_memberships:
       requested_ns = body_dict['namespace']
       privileged_namespace_re = '(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$|^redhat-.*)'

--- a/src/webhook/request_helper/validate.py
+++ b/src/webhook/request_helper/validate.py
@@ -6,6 +6,10 @@ def validate_request_structure(request_json):
 
   if 'kind' not in doc_keys:
     return False
+  
+  if 'userInfo' not in doc_keys:
+    return False
+
   if request_json['kind'] == "AdmissionReview":
     return True
   return False

--- a/templates/20-validation-webhook.deployment.yaml.tmpl
+++ b/templates/20-validation-webhook.deployment.yaml.tmpl
@@ -33,8 +33,8 @@ spec:
           value: "openshift-marketplace"
         - name: GROUP_VALIDATION_ADMIN_GROUP
           value: "osd-sre-admins,osd-sre-cluster-admins"
-        - name: GROUP_VALIDATION_PREFIX
-          value: "osd-sre-"
+        - name: GROUP_VALIDATION_PROTECTED_GROUP_REGEX
+          value: "(^osd-sre.*|^dedicated-admins$|^cluster-admins$|^layered-cs-sre-admins$)"
         command: 
         - gunicorn
         - --config


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3276

There were some test issues exposed, I had to move some global vars in tests to test class scope.
This is based on https://github.com/openshift/managed-cluster-validating-webhooks/pull/63 and I had to make some more changes.

I will cleanup README in a bit, env vars changed a bit with this update.